### PR TITLE
Move dependency to the subfolder so we can only build the sub-folder

### DIFF
--- a/che-theia-task-extension/package.json
+++ b/che-theia-task-extension/package.json
@@ -45,5 +45,8 @@
       "frontend": "lib/browser/che-frontend-module",
       "backend": "lib/node/che-backend-module"
     }
-  ]
+  ],
+  "resolutions": {
+    "node-pty": "0.7.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,5 @@
   },
   "workspaces": [
     "che-theia-task-extension", "browser-app"
-  ],
-  "resolutions": {
-    "node-pty": "0.7.4"
-  }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5438,9 +5438,9 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-"moxios@git://github.com/stoplightio/moxios.git#v1.3.0":
+"moxios@git://github.com/stoplightio/moxios#v1.3.0":
   version "1.3.0"
-  resolved "git://github.com/stoplightio/moxios.git#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
+  resolved "git://github.com/stoplightio/moxios#9d702c8eafee4b02917d6bc400ae15f1e835cf51"
   dependencies:
     class-autobind "^0.1.4"
 
@@ -5590,7 +5590,7 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pty@0.7.4, node-pty@^0.7.0:
+node-pty@^0.7.0:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-0.7.4.tgz#07146b2b40b76e432e57ce6750bda40f0da5c99f"
   dependencies:


### PR DESCRIPTION
removing all parent folder, etc

It's allowing to clone and build only subpart of the module. We're using it to rebuild all extensions for the Theia/Che image