### PR TITLE
CHE-10657 add support for the macros 'current.project.path'

### DIFF
--- a/che-theia-task-extension/src/browser/che-frontend-module.ts
+++ b/che-theia-task-extension/src/browser/che-frontend-module.ts
@@ -26,11 +26,13 @@ import { PreviewUrlIndicator } from './preview-url-indicator';
 import { PreviewUrlQuickOpen } from './preview-url-quick-open';
 import { ServerVariablesContribution } from './server-variables-contribution';
 import { CheWorkspaceClient } from '../common/che-workspace-client';
+import { ProjectPathVariableContribution } from "./che-task-variables-contribution";
 
 export default new ContainerModule(bind => {
     bind(CheWorkspaceClient).toSelf().inSingletonScope();
 
     bind(VariableContribution).to(ServerVariablesContribution).inSingletonScope();
+    bind(VariableContribution).to(ProjectPathVariableContribution).inSingletonScope();
 
     bind(MachinePicker).toSelf().inSingletonScope();
 

--- a/che-theia-task-extension/src/browser/che-frontend-module.ts
+++ b/che-theia-task-extension/src/browser/che-frontend-module.ts
@@ -26,7 +26,7 @@ import { PreviewUrlIndicator } from './preview-url-indicator';
 import { PreviewUrlQuickOpen } from './preview-url-quick-open';
 import { ServerVariablesContribution } from './server-variables-contribution';
 import { CheWorkspaceClient } from '../common/che-workspace-client';
-import { ProjectPathVariableContribution } from "./che-task-variables-contribution";
+import { ProjectPathVariableContribution } from './che-task-variables-contribution';
 
 export default new ContainerModule(bind => {
     bind(CheWorkspaceClient).toSelf().inSingletonScope();

--- a/che-theia-task-extension/src/browser/che-task-variables-contribution.ts
+++ b/che-theia-task-extension/src/browser/che-task-variables-contribution.ts
@@ -38,11 +38,11 @@ export class ProjectPathVariableContribution implements VariableContribution {
             name: 'current.project.path',
             description: 'The path of the project root folder',
             resolve: async () => {
-                let errorMessage = 'Get \'current.project.path\' variable error. ';
+                let errorMessage = 'Can not resolve \'current.project.path\' variable. ';
 
                 const selection = this.selectionService.selection;
                 if (!Array.isArray(selection) || !selection[0] || !selection[0].fileStat || !selection[0].fileStat.uri) {
-                    errorMessage += 'Any selections are not defined in the project tree.';
+                    errorMessage += 'No item selected in the project explorer.';
                     await this.messageService.error(errorMessage);
                     return undefined;
                 }
@@ -68,7 +68,7 @@ export class ProjectPathVariableContribution implements VariableContribution {
 
                 const relativeSelectionPath = selectionUri.substr(rootWorkspaceUri.length);
                 if (!relativeSelectionPath.length) {
-                    errorMessage += 'The selection is on workspace root folder. Select a project.';
+                    errorMessage += 'Workspace root folder is selected and is not a project. Please select a project.';
                     await this.messageService.error(errorMessage);
                     return undefined;
                 }

--- a/che-theia-task-extension/src/browser/che-task-variables-contribution.ts
+++ b/che-theia-task-extension/src/browser/che-task-variables-contribution.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import {inject, injectable} from 'inversify';
+import {VariableContribution, VariableRegistry} from '@theia/variable-resolver/lib/browser';
+import {CheWorkspaceClient} from '../common/che-workspace-client';
+import {WorkspaceService} from '@theia/workspace/lib/browser/workspace-service';
+import {SelectionService} from '@theia/core/lib/common';
+import URI from '@theia/core/lib/common/uri';
+
+/**
+ * Contributes the path for current project as a relative path to the first directory under the root workspace.
+ */
+@injectable()
+export class ProjectPathVariableContribution implements VariableContribution {
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+    @inject(CheWorkspaceClient)
+    protected readonly cheWsClient: CheWorkspaceClient;
+    @inject(SelectionService)
+    protected readonly selectionService: SelectionService;
+
+    async registerVariables(variables: VariableRegistry): Promise<void> {
+
+        variables.registerVariable({
+            name: 'current.project.path',
+            description: 'The path of the project root folder',
+            resolve: async () => {
+                const wsRoot = await this.workspaceService.root;
+                if (!wsRoot || !wsRoot.uri) {
+                    return undefined;
+                }
+                const rootWorkspaceUri = new URI(wsRoot.uri);
+
+                const selection = this.selectionService.selection;
+                if (!Array.isArray(selection) || !selection[0] || !selection[0].fileStat) {
+                    return undefined;
+                }
+                const selectionUri = new URI(selection[0]!.fileStat!.uri);
+
+                const rootWorkspacePath = rootWorkspaceUri.path.toString();
+                const selectionPath = selectionUri.path.toString();
+                if (!selectionPath.startsWith(rootWorkspacePath)) {
+                    return undefined;
+                }
+
+                const relativeSelectionPath = selectionPath.substr(rootWorkspacePath.length);
+                if (!relativeSelectionPath.length) {
+                    return undefined;
+                }
+                const splitter = '/';
+                const dirIndex = relativeSelectionPath[0] === splitter ? 1 : 0;
+
+                return relativeSelectionPath.split(splitter)[dirIndex];
+            }
+        });
+    }
+}


### PR DESCRIPTION
Add support for the macros 'current.project.path'.

Related issue: https://github.com/eclipse/che/issues/10657

Signed-off-by: Oleksii Orel <oorel@redhat.com>