### PR TITLE
Fix resolving the URLs

### DIFF
--- a/che-theia-task-extension/src/browser/che-terminal-widget.ts
+++ b/che-theia-task-extension/src/browser/che-terminal-widget.ts
@@ -9,10 +9,12 @@
  **********************************************************************/
 
 import { injectable, inject } from 'inversify';
+import { Disposable } from '@theia/core/lib/common';
+import URI from '@theia/core/lib/common/uri';
 import { TerminalWidgetOptions } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalWidgetImpl } from '@theia/terminal/lib/browser/terminal-widget-impl';
 import { CheWorkspaceClientService } from '../common/che-workspace-client-service';
-import { Disposable } from '@theia/core/lib/common';
+import { ATTACH_TERMINAL_SEGMENT } from '../common/terminal-protocol';
 
 export const CHE_TERMINAL_WIDGET_FACTORY_ID = 'che_terminal';
 
@@ -42,8 +44,9 @@ export class CheTerminalWidget extends TerminalWidgetImpl {
     }
 
     protected async connectTerminalProcess(): Promise<void> {
-        const termServer = await this.cheWorkspaceClient.getMachineExecServerURL();
-        const websocketStream = await new RWS(`${termServer}/attach/${this.terminalId}`, [], RECONNECTING_OPTIONS);
+        const termServerEndpoint = await this.cheWorkspaceClient.getMachineExecServerURL();
+        const terminalURL = new URI(termServerEndpoint).resolve(ATTACH_TERMINAL_SEGMENT).resolve(`${this.terminalId}`);
+        const websocketStream = await new RWS(terminalURL.toString(), [], RECONNECTING_OPTIONS);
 
         websocketStream.addEventListener('error', (event: Event) => {
             console.error('WebsocketStream error:', event);

--- a/che-theia-task-extension/src/common/terminal-protocol.ts
+++ b/che-theia-task-extension/src/common/terminal-protocol.ts
@@ -1,0 +1,12 @@
+/*********************************************************************
+ * Copyright (c) 2018 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+export const CONNECT_TERMINAL_SEGMENT = 'connect';
+export const ATTACH_TERMINAL_SEGMENT = 'attach';

--- a/che-theia-task-extension/src/node/che-task-runner.ts
+++ b/che-theia-task-extension/src/node/che-task-runner.ts
@@ -23,9 +23,6 @@ export class CheTaskRunner implements TaskRunner {
     @inject(MachineExecClientFactory)
     protected readonly machineExecClientFactory: MachineExecClientFactory;
 
-    @inject(MachineExecClientFactory)
-    protected readonly execAttachClientFactory: MachineExecClientFactory;
-
     @inject(TaskManager)
     protected readonly taskManager: TaskManager;
 
@@ -60,9 +57,6 @@ export class CheTaskRunner implements TaskRunner {
             await  this.machineExecClientFactory.fetchMachineExecServerURL();
             const execCreateClient = this.machineExecClientFactory.createExecClient();
             execId = await execCreateClient.create(machineExec);
-
-            const execAttachClient = this.execAttachClientFactory.createAttachClient(execId);
-            execAttachClient.attach();
 
             return this.taskFactory({
                 label: taskConfig.label,

--- a/che-theia-task-extension/src/node/machine-exec-client.ts
+++ b/che-theia-task-extension/src/node/machine-exec-client.ts
@@ -9,8 +9,10 @@
  **********************************************************************/
 
 import { injectable, inject, postConstruct } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
 import { JsonRpcProxyProvider } from './json-rpc-proxy-provider';
 import { CheWorkspaceClientService } from '../common/che-workspace-client-service';
+import { CONNECT_TERMINAL_SEGMENT, ATTACH_TERMINAL_SEGMENT } from '../common/terminal-protocol';
 
 export interface MachineIdentifier {
     workspaceId: string,
@@ -61,7 +63,8 @@ export class MachineExecClientFactory {
             throw new Error('Machine-exec server is not found in the current workspace.');
         }
         if (!this.execClient) {
-            this.execClient = this.jsonRpcProxyProvider.createProxy<ExecCreateClient>(`${this.machineExecServerEndpoint}/connect`);
+            const url = new URI(this.machineExecServerEndpoint).resolve(CONNECT_TERMINAL_SEGMENT);
+            this.execClient = this.jsonRpcProxyProvider.createProxy<ExecCreateClient>(url.toString());
         }
         return this.execClient;
     }
@@ -70,6 +73,7 @@ export class MachineExecClientFactory {
         if (this.machineExecServerEndpoint === undefined) {
             throw new Error('Machine-exec server is not found in the current workspace.');
         }
-        return this.jsonRpcProxyProvider.createProxy<ExecAttachClient>(`${this.machineExecServerEndpoint}/attach/${id}`);
+        const url = new URI(this.machineExecServerEndpoint).resolve(ATTACH_TERMINAL_SEGMENT).resolve(`${id}`);
+        return this.jsonRpcProxyProvider.createProxy<ExecAttachClient>(url.toString());
     }
 }


### PR DESCRIPTION
The PR fixes two issues:
- the issue with trailing slashes in URLs - adds resolving the URLs with Theia's [`URI`](https://github.com/theia-ide/theia/blob/master/packages/core/src/common/uri.ts) instead of relying on string concatenation;
- removes unnecessary `attach` request to `machine-exec` server since it causes the error
```
{"jsonrpc":"2.0","id":0,"method":"attach","params":null}{"jsonrpc":"2.0","id":0,"error":{"code":-32601,"message":"Unhandled method attach"}}
```

closes https://github.com/eclipse/che/issues/12125